### PR TITLE
🎨 Palette: Improve theme toggle accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - [Accessible Theme Toggle]
+**Learning:** Icon-only buttons for theme toggling should always have dynamic ARIA labels and titles that describe the *next* state (the action) rather than the current state, to provide clear feedback for both screen reader and mouse users.
+**Action:** Always check if theme toggles or similar state-switchers have descriptive, state-aware labels.

--- a/_includes/toggle_theme_button.html
+++ b/_includes/toggle_theme_button.html
@@ -1,4 +1,4 @@
-<button title="Toggle Theme" class="theme-toggle">
+<button title="Toggle Theme" class="theme-toggle" aria-label="Toggle Theme">
   <svg viewBox="0 0 32 32" width="24" height="24" fill="currentcolor">
     <circle cx="16" cy="16" r="14" fill="none" stroke="currentcolor" stroke-width="4"></circle>
     <path d="

--- a/_includes/toggle_theme_js.html
+++ b/_includes/toggle_theme_js.html
@@ -7,16 +7,27 @@
   function themeChange() {
     let button = document.querySelector('.theme-toggle');
 
+    const updateButton = (theme) => {
+      const isDark = theme === 'dark';
+      const label = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+      button.setAttribute('aria-label', label);
+      button.setAttribute('title', label);
+    };
+
+    updateButton(document.documentElement.getAttribute('data-theme'));
+
     button.addEventListener('click', function (e) {
       let currentTheme = document.documentElement.getAttribute('data-theme');
       if (currentTheme === 'dark') {
         transition();
         document.documentElement.setAttribute('data-theme', 'light');
         localStorage.setItem('theme', 'light');
+        updateButton('light');
       } else {
         transition();
         document.documentElement.setAttribute('data-theme', 'dark');
         localStorage.setItem('theme', 'dark');
+        updateButton('dark');
       }
     });
 


### PR DESCRIPTION
This PR improves the accessibility of the theme toggle button. 

Previously, the button was an icon-only button with a static title "Toggle Theme", which provided limited information to screen reader users and no feedback on the current/next state.

Changes:
- Added an initial `aria-label="Toggle Theme"` to `_includes/toggle_theme_button.html`.
- Updated `_includes/toggle_theme_js.html` to dynamically change the `aria-label` and `title` to "Switch to light mode" or "Switch to dark mode" depending on the active theme.

This makes the interaction more intuitive and accessible.

---
*PR created automatically by Jules for task [5130038781206527639](https://jules.google.com/task/5130038781206527639) started by @yunzck8s*