### PR TITLE
🎨 Palette: Enhance theme toggle accessibility and visual feedback

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-24 - Enhancing Theme Toggle Accessibility & Delight
+**Learning:** For icon-only buttons like theme switchers, `aria-label` and `aria-pressed` must be dynamically updated in sync with the state to provide a consistent experience for screen reader users. Additionally, using `:focus-visible` allows for a more prominent focus indicator for keyboard users without cluttering the UI for mouse users.
+**Action:** Always verify that state-changing icon buttons reflect their current and future state via ARIA attributes, and prioritize `:focus-visible` for accessible focus states.

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .jekyll-cache
 .sass-cache
 _site
+vendor/bundle

--- a/_includes/toggle_theme_button.html
+++ b/_includes/toggle_theme_button.html
@@ -1,4 +1,4 @@
-<button title="Toggle Theme" class="theme-toggle">
+<button title="Toggle Theme" class="theme-toggle" aria-label="Toggle dark mode" aria-pressed="false">
   <svg viewBox="0 0 32 32" width="24" height="24" fill="currentcolor">
     <circle cx="16" cy="16" r="14" fill="none" stroke="currentcolor" stroke-width="4"></circle>
     <path d="

--- a/_includes/toggle_theme_js.html
+++ b/_includes/toggle_theme_js.html
@@ -7,16 +7,31 @@
   function themeChange() {
     let button = document.querySelector('.theme-toggle');
 
+    function updateButton(theme) {
+      if (theme === 'dark') {
+        button.setAttribute('aria-label', 'Switch to light mode');
+        button.setAttribute('aria-pressed', 'true');
+      } else {
+        button.setAttribute('aria-label', 'Switch to dark mode');
+        button.setAttribute('aria-pressed', 'false');
+      }
+    }
+
+    // Initialize button state
+    updateButton(document.documentElement.getAttribute('data-theme'));
+
     button.addEventListener('click', function (e) {
       let currentTheme = document.documentElement.getAttribute('data-theme');
       if (currentTheme === 'dark') {
         transition();
         document.documentElement.setAttribute('data-theme', 'light');
         localStorage.setItem('theme', 'light');
+        updateButton('light');
       } else {
         transition();
         document.documentElement.setAttribute('data-theme', 'dark');
         localStorage.setItem('theme', 'dark');
+        updateButton('dark');
       }
     });
 
@@ -28,4 +43,3 @@
     }
   }
 </script>
-

--- a/_sass/moonwalk.scss
+++ b/_sass/moonwalk.scss
@@ -391,6 +391,14 @@ th {
 }
 
 /* Animations */
+.transition,
+.transition *,
+.transition *:before,
+.transition *:after {
+  transition: all 750ms !important;
+  transition-delay: 0 !important;
+}
+
 @keyframes fadeInUp {
   from {
     opacity: 0;
@@ -484,10 +492,16 @@ html {
   outline-offset: 2px;
 }
 
-.theme-toggle:focus {
-  outline: 2px solid var(--accent-primary);
-  outline-offset: 2px;
+.theme-toggle:focus:not(:focus-visible) {
+  outline: none;
 }
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 4px;
+  box-shadow: 0 0 0 4px var(--bg-primary), 0 0 0 6px var(--accent-primary);
+}
+
 
 /* Print styles */
 @media print {


### PR DESCRIPTION
This PR adds a micro-UX improvement to the theme toggle button, focusing on accessibility and delightful transitions.

### 💡 What
- Added `aria-label` and `aria-pressed` to the theme toggle button in `_includes/toggle_theme_button.html`.
- Updated `_includes/toggle_theme_js.html` to dynamically update these ARIA attributes when the theme is toggled.
- Added a `.transition` CSS class in `_sass/moonwalk.scss` to enable smooth transitions between themes.
- Improved focus states in `_sass/moonwalk.scss` using `:focus-visible` to provide a clear indicator for keyboard users while keeping it clean for mouse users.
- Initialized the UX journal in `.Jules/palette.md` with critical learnings.

### 🎯 Why
- **Accessibility:** Icon-only buttons need proper ARIA labels and state indicators to be usable by screen reader users.
- **Visual Feedback:** A smooth transition makes the theme switch feel more polished and "delightful".
- **Keyboard UX:** Standard focus outlines can be visually distracting for mouse users but are essential for keyboard users. `:focus-visible` provides the best of both worlds.

### ♿ Accessibility
- Screen readers now announce the current state of the theme and what the button will do.
- Keyboard users have a much clearer focus indicator.
- Reduced visual noise for mouse users while maintaining accessibility standards.

---
*PR created automatically by Jules for task [8075787836363783727](https://jules.google.com/task/8075787836363783727) started by @yunzck8s*