### PR TITLE
🎨 Palette: Add 'Skip to content' link for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -3,3 +3,9 @@
 **Learning:** Using `*:focus-visible` instead of `*:focus` provides a better experience by only showing focus rings for keyboard users, reducing visual noise for mouse users. Implementing a global `.transition` class managed by JS allows for smooth theme switching without interfering with normal component transitions.
 
 **Action:** Always prefer `focus-visible` for focus indicators and use the `.transition` utility pattern for global state changes that affect many components.
+
+## 2026-05-23 - Accessibility: Skip to Content
+
+**Learning:** "Skip to content" links are essential for keyboard and screen reader users to bypass repetitive navigation. They should be the first focusable element in the DOM and use `tabindex="-1"` on the target container to ensure programmatic focus works correctly in all browsers.
+
+**Action:** Implement "Skip to content" links in all multi-page layouts, ensuring the target container has a unique ID and proper `tabindex`.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,11 +2,12 @@
 <html lang="{{ page.lang | default: "en" }}" class="html" data-theme="{{ site.theme_config.appearance | default: "auto" }}">
   {%- include head.html -%}
   <body>
+    <a class="skip-link" href="#main-content">Skip to content</a>
     {% if site.theme_config.appearance_toggle %}
       {% include toggle_theme_button.html %}
     {% endif %}
     
-    <div class="container">
+    <div class="container" id="main-content" tabindex="-1">
       {{ content }}
     </div>
 

--- a/_sass/moonwalk.scss
+++ b/_sass/moonwalk.scss
@@ -103,6 +103,26 @@ a:hover {
   border-bottom-color: var(--accent-secondary);
 }
 
+/* Accessibility */
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--accent-primary);
+  color: white;
+  padding: 8px;
+  z-index: 1001;
+  transition: top 0.3s;
+  text-decoration: none;
+  border-bottom-right-radius: var(--radius-md);
+}
+
+.skip-link:focus {
+  top: 0;
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
 /* Layout */
 .container {
   max-width: 768px;


### PR DESCRIPTION
Implemented a "Skip to content" link as a micro-UX enhancement for accessibility.

💡 What:
- Added `<a class="skip-link" href="#main-content">Skip to content</a>` at the beginning of the body.
- Added `id="main-content"` and `tabindex="-1"` to the main container.
- Added CSS to keep the skip link hidden until focused.

🎯 Why:
- Improves accessibility by allowing keyboard users and screen readers to jump directly to the main content, bypassing navigation links.

♿ Accessibility:
- Follows standard patterns for skip links.
- Uses `tabindex="-1"` to ensure programmatic focus works correctly in all browsers.
- Only visible when focused, avoiding visual noise for mouse users.

---
*PR created automatically by Jules for task [12987092914785333770](https://jules.google.com/task/12987092914785333770) started by @yunzck8s*